### PR TITLE
Escape " in paths on non-Win platforms

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,10 +66,10 @@ export function activate(context: vscode.ExtensionContext) {
       const cmdScript = rulesPath
         ? `set echo on
 format rules ${rulesPath}
-format file "${tempFile}" "${tempFile}"
+format file \\\"${tempFile}\\\" \\\"${tempFile}\\\"
 exit`
         : `set echo on
-format file "${tempFile}" "${tempFile}"
+format file \\\"${tempFile}\\\" \\\"${tempFile}\\\"
 exit`;
       const formatScript = join(storagePath, "format.sql");
 


### PR DESCRIPTION
@rafael-trevisan , I cannot push to your fork so this is a continutation of #9 .

I did a replace of " with escaped " as you suggested for non-Win platform. I will be delighted if you could test. :) 

