### PR TITLE
Add default support for Oracle Developer Tools for VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         },
         "oracle-format.languages": {
           "type": "array",
-          "default": ["plsql"],
+          "default": ["plsql" , "oraclesql"],
           "required": false,
           "description": "Languages associated with formatter"
         }


### PR DESCRIPTION
to make it easy for users , add the "oraclesql" language to the default languages ("oraclesql" used by the oracle official extension "Oracle Developer Tools for VS Code") to make it work out of the box with Oracle's extension.